### PR TITLE
Fix MacOS security settings blocking the downloaded Obsidian installers

### DIFF
--- a/packages/wdio-obsidian-service/README.md
+++ b/packages/wdio-obsidian-service/README.md
@@ -200,9 +200,7 @@ it("test the thing", async function() {
 Testing on iOS is currently not supported.
 
 ### MacOS
-MacOS security settings will sometimes block the downloaded Obsidian executables from running with errors like `Obsidian is damaged and can't be opened. You should move it to the Trash. This file was downloaded on an unknown date`. You can fix this by setting the executable as allowed in "Privacy & Security" settings. See this [comment on issue #46](https://github.com/jesse-r-s-hines/wdio-obsidian-service/issues/46#issuecomment-3419205737) for instructions.
-
-If anybody more Mac-savvy knows how to prevent triggering this security check, a PR would be much appreciated! 😅
+MacOS security settings will sometimes block the downloaded Obsidian executables from running with errors like `Obsidian is damaged and can't be opened. This file was downloaded on an unknown date`. You can work around this by setting the executable as allowed in "Privacy & Security" settings. See this [comment on issue #46](https://github.com/jesse-r-s-hines/wdio-obsidian-service/issues/46#issuecomment-3419205737) for instructions.
 
 ### Mobile Emulation
 


### PR DESCRIPTION
Use hdiutil to extract Obsidian on Mac. This seems to resolve Mac security settings blocking the downloaded Obsidian executable. See issue #46