### PR TITLE
feat: add `copy` option to wdio:obsidianOptions

### DIFF
--- a/packages/wdio-obsidian-service/src/browserCommands.ts
+++ b/packages/wdio-obsidian-service/src/browserCommands.ts
@@ -134,17 +134,20 @@ export type ObsidianBrowserCommands = typeof browserCommands & {
      * {@link ObsidianPage.resetVault} instead, which modifies vault files in place without rebooting Obsidian. If all
      * your tests use the same vault, you can also just set the vault in the `wdio.conf.mts` capabilities section.
      * 
-     * @param params.vault Path to the vault to open. The vault will be copied, so any changes made in your tests won't
-     *     be persited to the original. If omitted, it will reboot Obsidian with the current vault without creating a
-     *     new copy of the vault.
+     * @param params.vault Path to the vault to open. The vault will be copied by default, so any changes made in your
+     *     tests won't be persisted to the original. Set `copy` to `false` to use the vault in-place. If omitted, it
+     *     will reboot Obsidian with the current vault without creating a new copy of the vault.
+     * @param params.copy Whether to copy the vault to a temporary directory. Defaults to `false` if omitted, so that
+     *     reloading with a different vault doesn't unexpectedly copy it. Set to `true` to copy.
      * @param params.plugins List of plugin ids to enable. If omitted it will keep current plugin list. Note, all the
-     *     plugins must be defined in your wdio.conf.mts capabilities. You can also use the enablePlugin and 
+     *     plugins must be defined in your wdio.conf.mts capabilities. You can also use the enablePlugin and
      *     disablePlugin commands to change plugins without relaunching Obsidian.
      * @param params.theme Name of the theme to enable. If omitted it will keep the current theme. Pass "default" to
      *     switch back to the default theme. Like with plugins, the theme must be defined in wdio.conf.mts.
      */
     reloadObsidian(params?: {
         vault?: string,
+        copy?: boolean,
         plugins?: string[], theme?: string,
     }): Promise<void>;
     // This command is implemented in the service hooks.

--- a/packages/wdio-obsidian-service/src/browserCommands.ts
+++ b/packages/wdio-obsidian-service/src/browserCommands.ts
@@ -137,8 +137,7 @@ export type ObsidianBrowserCommands = typeof browserCommands & {
      * @param params.vault Path to the vault to open. The vault will be copied by default, so any changes made in your
      *     tests won't be persisted to the original. Set `copy` to `false` to use the vault in-place. If omitted, it
      *     will reboot Obsidian with the current vault without creating a new copy of the vault.
-     * @param params.copy Whether to copy the vault to a temporary directory. Defaults to `false` if omitted, so that
-     *     reloading with a different vault doesn't unexpectedly copy it. Set to `true` to copy.
+     * @param params.copy Whether to copy the vault to a temporary directory. Defaults to `true`.
      * @param params.plugins List of plugin ids to enable. If omitted it will keep current plugin list. Note, all the
      *     plugins must be defined in your wdio.conf.mts capabilities. You can also use the enablePlugin and
      *     disablePlugin commands to change plugins without relaunching Obsidian.

--- a/packages/wdio-obsidian-service/src/service.ts
+++ b/packages/wdio-obsidian-service/src/service.ts
@@ -481,7 +481,7 @@ export class ObsidianWorkerService implements Services.ServiceInstance {
         const service = this; // eslint-disable-line @typescript-eslint/no-this-alias
         const reloadObsidian: WebdriverIO.Browser['reloadObsidian'] = async function(
             this: WebdriverIO.Browser,
-            {vault, plugins, theme} = {},
+            {vault, copy = false, plugins, theme} = {},
         ) {
             const oldObsidianOptions = getNormalizedObsidianOptions(this.requestedCapabilities);
             const selectedPlugins = selectPlugins(oldObsidianOptions.plugins, plugins);
@@ -493,6 +493,7 @@ export class ObsidianWorkerService implements Services.ServiceInstance {
                 ...oldObsidianOptions,
                 // Resolve relative to PWD instead of root dir during tests
                 vault: vault ? path.resolve(vault) : oldObsidianOptions.vault,
+                copy,
                 plugins: selectedPlugins, themes: selectedThemes,
             };
 

--- a/packages/wdio-obsidian-service/src/service.ts
+++ b/packages/wdio-obsidian-service/src/service.ts
@@ -170,6 +170,7 @@ export class ObsidianLauncherService implements Services.ServiceInstance {
                     const normalizedObsidianOptions: NormalizedObsidianCapabilityOptions = {
                         ...obsidianOptions,
                         plugins, themes, vault: vault,
+                        copy: obsidianOptions.copy ?? true,
                         appVersion, installerVersion: appVersion,
                         emulateMobile: false,
                     }
@@ -211,6 +212,7 @@ export class ObsidianLauncherService implements Services.ServiceInstance {
                     const normalizedObsidianOptions: NormalizedObsidianCapabilityOptions = {
                         ...obsidianOptions,
                         plugins, themes, vault,
+                        copy: obsidianOptions.copy ?? true,
                         binaryPath: installerPath, appPath: appPath,
                         appVersion, installerVersion,
                         emulateMobile: obsidianOptions.emulateMobile ?? false,
@@ -277,20 +279,23 @@ export class ObsidianWorkerService implements Services.ServiceInstance {
     }
 
     /**
-     * Creates a copy of the vault with plugins and themes installed
+     * Sets up the vault with plugins and themes installed, optionally copying it first.
      */
     private async setupVault(cap: WebdriverIO.Capabilities) {
         const obsidianOptions = getNormalizedObsidianOptions(cap);
         let vaultCopy: string|undefined;
         if (obsidianOptions.vault != undefined) {
-            log.info(`Opening vault ${obsidianOptions.vault}`);
+            const shouldCopy = obsidianOptions.copy !== false;
+            log.info(`Opening vault ${obsidianOptions.vault}${shouldCopy ? ' (copy)' : ' (in-place)'}`);
             vaultCopy = await this.obsidianLauncher.setupVault({
                 vault: obsidianOptions.vault,
-                copy: true,
+                copy: shouldCopy,
                 plugins: obsidianOptions.plugins,
                 themes: obsidianOptions.themes,
             });
-            this.tmpDirs.push(vaultCopy);
+            if (shouldCopy) {
+                this.tmpDirs.push(vaultCopy);
+            }
         } else {
             log.info(`Opening Obsidian without a vault`)
         }

--- a/packages/wdio-obsidian-service/src/service.ts
+++ b/packages/wdio-obsidian-service/src/service.ts
@@ -481,7 +481,7 @@ export class ObsidianWorkerService implements Services.ServiceInstance {
         const service = this; // eslint-disable-line @typescript-eslint/no-this-alias
         const reloadObsidian: WebdriverIO.Browser['reloadObsidian'] = async function(
             this: WebdriverIO.Browser,
-            {vault, copy = false, plugins, theme} = {},
+            {vault, copy = true, plugins, theme} = {},
         ) {
             const oldObsidianOptions = getNormalizedObsidianOptions(this.requestedCapabilities);
             const selectedPlugins = selectPlugins(oldObsidianOptions.plugins, plugins);

--- a/packages/wdio-obsidian-service/src/types.ts
+++ b/packages/wdio-obsidian-service/src/types.ts
@@ -94,11 +94,10 @@ export interface ObsidianCapabilityOptions {
      * Whether to copy the vault to a temporary directory before running tests.
      *
      * When `true` (the default), the vault is copied so that tests don't modify the original. When `false`, the
-     * vault is used in-place — useful for interactive/debug sessions or read-only tests on large vaults where
-     * copying is expensive.
+     * vault is used in-place, useful for debugging or read-only tests on large vaults.
      *
-     * **Warning:** With `copy: false`, any changes made by tests (or by Obsidian itself) will persist in the
-     * original vault.
+     * Note that, even with "read-only" tests `copy: false` will persist changes made by Obsidian and
+     * wdio-obsidian-service such as installed plugins and other files under `.obsidian`.
      *
      * Defaults to `true`.
      */

--- a/packages/wdio-obsidian-service/src/types.ts
+++ b/packages/wdio-obsidian-service/src/types.ts
@@ -82,12 +82,27 @@ export interface ObsidianCapabilityOptions {
 
     /**
      * The path to the vault to open.
-     * 
-     * The vault will be copied, so any changes made in your tests won't affect the original. If omitted, no vault will
-     * be opened and you'll need to call {@link ObsidianBrowserCommands.reloadObsidian|browser.reloadObsidian} to open a
-     * vault during your tests. Path is relative to your `wdio.conf.mts`.
+     *
+     * By default the vault will be copied to a temporary directory, so any changes made in your tests won't affect
+     * the original. Set {@link copy} to `false` to use the vault in-place. If omitted, no vault will be opened and
+     * you'll need to call {@link ObsidianBrowserCommands.reloadObsidian|browser.reloadObsidian} to open a vault
+     * during your tests. Path is relative to your `wdio.conf.mts`.
      */
     vault?: string,
+
+    /**
+     * Whether to copy the vault to a temporary directory before running tests.
+     *
+     * When `true` (the default), the vault is copied so that tests don't modify the original. When `false`, the
+     * vault is used in-place — useful for interactive/debug sessions or read-only tests on large vaults where
+     * copying is expensive.
+     *
+     * **Warning:** With `copy: false`, any changes made by tests (or by Obsidian itself) will persist in the
+     * original vault.
+     *
+     * Defaults to `true`.
+     */
+    copy?: boolean,
 
     /**
      * Set to true to emulate mobile on the Electron desktop app. This uses Obsidian `app.emulateMobile()` to switch
@@ -124,6 +139,7 @@ export interface NormalizedObsidianCapabilityOptions {
     plugins: DownloadedPluginEntry[],
     themes: DownloadedThemeEntry[],
     vault?: string,
+    copy: boolean,
     vaultCopy?: string,
     /** Path of the vault on the appium device */
     uploadedVault?: string,

--- a/packages/wdio-obsidian-service/test/standalone/standalone.spec.ts
+++ b/packages/wdio-obsidian-service/test/standalone/standalone.spec.ts
@@ -42,3 +42,38 @@ describe("standalone mode test", function() {
         expect(path.basename(vaultPath)).to.match(/^basic-/);
     });
 })
+
+describe("standalone mode no-copy vault test", function() {
+    let browser: WebdriverIO.Browser|undefined;
+    before(async function() {
+        this.timeout("10m");
+        browser = await startWdioSession({
+            capabilities: {
+                browserName: "obsidian",
+                browserVersion: "latest",
+                'wdio:obsidianOptions': {
+                    installerVersion: "latest",
+                    plugins: [
+                        "./test/plugins/basic-plugin",
+                    ],
+                    vault: "./test/vaults/basic",
+                    copy: false,
+                },
+            },
+            cacheDir: cacheDir,
+            logLevel: "warn",
+        }, obsidianServiceOptions)
+    });
+    after(async function() {
+        this.timeout("10s");
+        await browser?.deleteSession();
+    });
+    this.timeout("30s");
+
+    it("uses vault in-place when copy is false", async function() {
+        const vaultPath = await browser!.executeObsidian(({app}) => (app.vault.adapter as any).getFullPath(""));
+        // With copy: false, the vault should be used in-place, so the path should end with the original vault name
+        // (not a temp copy with a random suffix like "basic-xxxxx")
+        expect(vaultPath).to.match(/\/basic\/?$/);
+    });
+})

--- a/packages/wdio-obsidian-service/test/standalone/standalone.spec.ts
+++ b/packages/wdio-obsidian-service/test/standalone/standalone.spec.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { describe, it } from "mocha";
 import { expect } from "chai";
+import { createDirectory } from "../helpers.js";
 import { startWdioSession } from "wdio-obsidian-service"
 import { fileURLToPath, pathToFileURL } from "url"
 
@@ -45,7 +46,9 @@ describe("standalone mode test", function() {
 
 describe("standalone mode no-copy vault test", function() {
     let browser: WebdriverIO.Browser|undefined;
+    let vault: string|undefined
     before(async function() {
+        vault = await createDirectory({"Hello.md": "Hello World"});
         this.timeout("10m");
         browser = await startWdioSession({
             capabilities: {
@@ -56,7 +59,7 @@ describe("standalone mode no-copy vault test", function() {
                     plugins: [
                         "./test/plugins/basic-plugin",
                     ],
-                    vault: "./test/vaults/basic",
+                    vault: vault,
                     copy: false,
                 },
             },
@@ -74,6 +77,7 @@ describe("standalone mode no-copy vault test", function() {
         const vaultPath = await browser!.executeObsidian(({app}) => (app.vault.adapter as any).getFullPath(""));
         // With copy: false, the vault should be used in-place, so the path should end with the original vault name
         // (not a temp copy with a random suffix like "basic-xxxxx")
-        expect(vaultPath).to.match(/\/basic\/?$/);
+        expect(vaultPath).to.eql(vault);
+        expect(browser!.getObsidianPage().getVaultPath()).to.eql(vault)
     });
 })


### PR DESCRIPTION
## Summary

- Adds a `copy` option (default: `true`) to `wdio:obsidianOptions` that controls whether the vault is copied to a temp directory before tests
- When `copy: false`, the vault is used in-place and is not added to `tmpDirs` (so `afterSession` won't delete it)
- The underlying `obsidian-launcher` already supports `copy: false` — this change exposes it through the service config

## Use case

Interactive/debug sessions and read-only tests on large vaults where copying is expensive and unnecessary.

```ts
capabilities: [{
    browserName: 'obsidian',
    'wdio:obsidianOptions': {
        vault: '/path/to/vault',
        copy: false,  // Use vault in-place
    }
}]
```

## Changes

- `types.ts`: Added `copy?: boolean` to `ObsidianCapabilityOptions` and `copy: boolean` to `NormalizedObsidianCapabilityOptions`
- `service.ts`: `setupVault()` respects `copy` option; `onPrepare()` passes it through to normalized options

No breaking changes — defaults to `true` (current behavior).

Closes #65