### PR TITLE
Add minRunnableInstallerVersion

### DIFF
--- a/obsidian-versions.json
+++ b/obsidian-versions.json
@@ -1,9 +1,9 @@
 {
     "metadata": {
-        "schemaVersion": "2.0.0",
+        "schemaVersion": "2.1.0",
         "commitDate": "2026-06-09T20:58:23Z",
         "commitSha": "43e0c875353e4abc55315ccb7182e0fb1b512591",
-        "timestamp": "2026-07-10T04:27:24.340Z"
+        "timestamp": "2026-07-13T14:01:33.770Z"
     },
     "versions": [
         {
@@ -81,6 +81,7 @@
         {
             "version": "0.6.4",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.6.4",
@@ -123,6 +124,7 @@
         {
             "version": "0.6.5",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.6.5",
@@ -165,6 +167,7 @@
         {
             "version": "0.6.6",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.6.6",
@@ -176,6 +179,7 @@
         {
             "version": "0.6.7",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.6.7",
@@ -218,6 +222,7 @@
         {
             "version": "0.7.0",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.7",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.0",
@@ -229,6 +234,7 @@
         {
             "version": "0.7.1",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.7",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.1",
@@ -240,6 +246,7 @@
         {
             "version": "0.7.2",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.6.7",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.2",
@@ -251,6 +258,7 @@
         {
             "version": "0.7.3",
             "minInstallerVersion": "0.6.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.7.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.3",
@@ -293,6 +301,7 @@
         {
             "version": "0.7.4",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.7.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.4",
@@ -335,6 +344,7 @@
         {
             "version": "0.7.5",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.7.4",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.5",
@@ -346,6 +356,7 @@
         {
             "version": "0.7.6",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.7.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.7.6",
@@ -388,6 +399,7 @@
         {
             "version": "0.8.0",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.0",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.0",
@@ -430,6 +442,7 @@
         {
             "version": "0.8.1",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.1",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.1",
@@ -472,6 +485,7 @@
         {
             "version": "0.8.2",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.2",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.2",
@@ -514,6 +528,7 @@
         {
             "version": "0.8.3",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.2",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.3",
@@ -525,6 +540,7 @@
         {
             "version": "0.8.4",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.4",
@@ -567,6 +583,7 @@
         {
             "version": "0.8.5",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.4",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.5",
@@ -578,6 +595,7 @@
         {
             "version": "0.8.6",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.4",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.6",
@@ -589,6 +607,7 @@
         {
             "version": "0.8.7",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.4",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.7",
@@ -600,6 +619,7 @@
         {
             "version": "0.8.8",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.4",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.8",
@@ -611,6 +631,7 @@
         {
             "version": "0.8.9",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.9",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.9",
@@ -653,6 +674,7 @@
         {
             "version": "0.8.10",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.9",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.10",
@@ -664,6 +686,7 @@
         {
             "version": "0.8.11",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.9",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.11",
@@ -675,6 +698,7 @@
         {
             "version": "0.8.12",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.12",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.12",
@@ -717,6 +741,7 @@
         {
             "version": "0.8.13",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.12",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.13",
@@ -728,6 +753,7 @@
         {
             "version": "0.8.14",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.14",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.14",
@@ -770,6 +796,7 @@
         {
             "version": "0.8.15",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.15",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.8.15",
@@ -812,6 +839,7 @@
         {
             "version": "0.9.0",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.8.15",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.0",
@@ -823,6 +851,7 @@
         {
             "version": "0.9.1",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.1",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.1",
@@ -874,6 +903,7 @@
         {
             "version": "0.9.2",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.2",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.2",
@@ -925,6 +955,7 @@
         {
             "version": "0.9.3",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.3",
@@ -976,6 +1007,7 @@
         {
             "version": "0.9.4",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.4",
@@ -1027,6 +1059,7 @@
         {
             "version": "0.9.5",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.4",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.5",
@@ -1038,6 +1071,7 @@
         {
             "version": "0.9.6",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.6",
@@ -1089,6 +1123,7 @@
         {
             "version": "0.9.7",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.6",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.7",
@@ -1100,6 +1135,7 @@
         {
             "version": "0.9.8",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.6",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.8",
@@ -1111,6 +1147,7 @@
         {
             "version": "0.9.9",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.6",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.9",
@@ -1122,6 +1159,7 @@
         {
             "version": "0.9.10",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.10",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.10",
@@ -1173,6 +1211,7 @@
         {
             "version": "0.9.11",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.11",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.11",
@@ -1224,6 +1263,7 @@
         {
             "version": "0.9.12",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.11",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.12",
@@ -1235,6 +1275,7 @@
         {
             "version": "0.9.13",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.11",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.13",
@@ -1246,6 +1287,7 @@
         {
             "version": "0.9.14",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.11",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.14",
@@ -1257,6 +1299,7 @@
         {
             "version": "0.9.15",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.15",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.15",
@@ -1308,6 +1351,7 @@
         {
             "version": "0.9.16",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.15",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.16",
@@ -1319,6 +1363,7 @@
         {
             "version": "0.9.17",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.17",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.17",
@@ -1388,6 +1433,7 @@
         {
             "version": "0.9.18",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.17",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.18",
@@ -1399,6 +1445,7 @@
         {
             "version": "0.9.19",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.17",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.19",
@@ -1410,6 +1457,7 @@
         {
             "version": "0.9.20",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.20",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.20",
@@ -1461,6 +1509,7 @@
         {
             "version": "0.9.21",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.20",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.21",
@@ -1472,6 +1521,7 @@
         {
             "version": "0.9.22",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.22",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.9.22",
@@ -1523,6 +1573,7 @@
         {
             "version": "0.10.0",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.9.22",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.0",
@@ -1534,6 +1585,7 @@
         {
             "version": "0.10.1",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.1",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.1",
@@ -1585,6 +1637,7 @@
         {
             "version": "0.10.2",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.1",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.2",
@@ -1596,6 +1649,7 @@
         {
             "version": "0.10.3",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.1",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.3",
@@ -1607,6 +1661,7 @@
         {
             "version": "0.10.4",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.1",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.4",
@@ -1618,6 +1673,7 @@
         {
             "version": "0.10.5",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.1",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.5",
@@ -1629,6 +1685,7 @@
         {
             "version": "0.10.6",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.6",
@@ -1680,6 +1737,7 @@
         {
             "version": "0.10.7",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.7",
@@ -1731,6 +1789,7 @@
         {
             "version": "0.10.8",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.8",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.8",
@@ -1782,6 +1841,7 @@
         {
             "version": "0.10.9",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.9",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.9",
@@ -1833,6 +1893,7 @@
         {
             "version": "0.10.10",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.9",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.10",
@@ -1844,6 +1905,7 @@
         {
             "version": "0.10.11",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.11",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.11",
@@ -1895,6 +1957,7 @@
         {
             "version": "0.10.12",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.11",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.12",
@@ -1906,6 +1969,7 @@
         {
             "version": "0.10.13",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.10.13",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.10.13",
@@ -1957,6 +2021,7 @@
         {
             "version": "0.11.0",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.0",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.0",
@@ -2008,6 +2073,7 @@
         {
             "version": "0.11.1",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.0",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.1",
@@ -2019,6 +2085,7 @@
         {
             "version": "0.11.2",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.0",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.2",
@@ -2030,6 +2097,7 @@
         {
             "version": "0.11.3",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.3",
@@ -2081,6 +2149,7 @@
         {
             "version": "0.11.4",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.3",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.4",
@@ -2092,6 +2161,7 @@
         {
             "version": "0.11.5",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.5",
@@ -2143,6 +2213,7 @@
         {
             "version": "0.11.6",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.6",
@@ -2154,6 +2225,7 @@
         {
             "version": "0.11.7",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.7",
@@ -2165,6 +2237,7 @@
         {
             "version": "0.11.8",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.8",
@@ -2176,6 +2249,7 @@
         {
             "version": "0.11.9",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.9",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.9",
@@ -2227,6 +2301,7 @@
         {
             "version": "0.11.10",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.9",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.10",
@@ -2238,6 +2313,7 @@
         {
             "version": "0.11.11",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.9",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.11",
@@ -2249,6 +2325,7 @@
         {
             "version": "0.11.12",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.9",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.12",
@@ -2260,6 +2337,7 @@
         {
             "version": "0.11.13",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.13",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.11.13",
@@ -2311,6 +2389,7 @@
         {
             "version": "0.12.0",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.13",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.0",
@@ -2322,6 +2401,7 @@
         {
             "version": "0.12.1",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.13",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.1",
@@ -2333,6 +2413,7 @@
         {
             "version": "0.12.2",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.11.13",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.2",
@@ -2344,6 +2425,7 @@
         {
             "version": "0.12.3",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.3",
@@ -2395,6 +2477,7 @@
         {
             "version": "0.12.4",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.4",
@@ -2446,6 +2529,7 @@
         {
             "version": "0.12.5",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.5",
@@ -2497,6 +2581,7 @@
         {
             "version": "0.12.6",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.6",
@@ -2508,6 +2593,7 @@
         {
             "version": "0.12.7",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.7",
@@ -2519,6 +2605,7 @@
         {
             "version": "0.12.8",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.8",
@@ -2530,6 +2617,7 @@
         {
             "version": "0.12.9",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.5",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.9",
@@ -2541,6 +2629,7 @@
         {
             "version": "0.12.10",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.10",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.10",
@@ -2592,6 +2681,7 @@
         {
             "version": "0.12.11",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.10",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.11",
@@ -2603,6 +2693,7 @@
         {
             "version": "0.12.12",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.12",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.12",
@@ -2654,6 +2745,7 @@
         {
             "version": "0.12.13",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.12",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.13",
@@ -2665,6 +2757,7 @@
         {
             "version": "0.12.14",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.12",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.14",
@@ -2676,6 +2769,7 @@
         {
             "version": "0.12.15",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.15",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.15",
@@ -2745,6 +2839,7 @@
         {
             "version": "0.12.17",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.15",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.17",
@@ -2756,6 +2851,7 @@
         {
             "version": "0.12.18",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.15",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.18",
@@ -2767,6 +2863,7 @@
         {
             "version": "0.12.19",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.12.19",
@@ -2818,6 +2915,7 @@
         {
             "version": "0.13.0",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2828,6 +2926,7 @@
         {
             "version": "0.13.1",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2838,6 +2937,7 @@
         {
             "version": "0.13.2",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2848,6 +2948,7 @@
         {
             "version": "0.13.3",
             "minInstallerVersion": "0.7.4",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2858,6 +2959,7 @@
         {
             "version": "0.13.4",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2868,6 +2970,7 @@
         {
             "version": "0.13.5",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2878,6 +2981,7 @@
         {
             "version": "0.13.6",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2888,6 +2992,7 @@
         {
             "version": "0.13.7",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2898,6 +3003,7 @@
         {
             "version": "0.13.8",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2908,6 +3014,7 @@
         {
             "version": "0.13.9",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2918,6 +3025,7 @@
         {
             "version": "0.13.10",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2928,6 +3036,7 @@
         {
             "version": "0.13.11",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2938,6 +3047,7 @@
         {
             "version": "0.13.12",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2948,6 +3058,7 @@
         {
             "version": "0.13.13",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.12.19",
             "isBeta": true,
             "downloads": {
@@ -2958,6 +3069,7 @@
         {
             "version": "0.13.14",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.14",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.14",
@@ -3009,6 +3121,7 @@
         {
             "version": "0.13.15",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.14",
             "isBeta": true,
             "downloads": {
@@ -3019,6 +3132,7 @@
         {
             "version": "0.13.16",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.14",
             "isBeta": true,
             "downloads": {
@@ -3029,6 +3143,7 @@
         {
             "version": "0.13.17",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.14",
             "isBeta": true,
             "downloads": {
@@ -3039,6 +3154,7 @@
         {
             "version": "0.13.18",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.14",
             "isBeta": true,
             "downloads": {
@@ -3049,6 +3165,7 @@
         {
             "version": "0.13.19",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.19",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.19",
@@ -3100,6 +3217,7 @@
         {
             "version": "0.13.20",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.19",
             "isBeta": true,
             "downloads": {
@@ -3110,6 +3228,7 @@
         {
             "version": "0.13.21",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.19",
             "isBeta": true,
             "downloads": {
@@ -3120,6 +3239,7 @@
         {
             "version": "0.13.22",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.19",
             "isBeta": true,
             "downloads": {
@@ -3130,6 +3250,7 @@
         {
             "version": "0.13.23",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.23",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.23",
@@ -3181,6 +3302,7 @@
         {
             "version": "0.13.24",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.24",
             "isBeta": true,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.24",
@@ -3232,6 +3354,7 @@
         {
             "version": "0.13.25",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.24",
             "isBeta": true,
             "downloads": {
@@ -3242,6 +3365,7 @@
         {
             "version": "0.13.26",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.24",
             "isBeta": true,
             "downloads": {
@@ -3252,6 +3376,7 @@
         {
             "version": "0.13.27",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.24",
             "isBeta": true,
             "downloads": {
@@ -3262,6 +3387,7 @@
         {
             "version": "0.13.28",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.24",
             "isBeta": true,
             "downloads": {
@@ -3272,6 +3398,7 @@
         {
             "version": "0.13.29",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.24",
             "isBeta": true,
             "downloads": {
@@ -3282,6 +3409,7 @@
         {
             "version": "0.13.30",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.30",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.30",
@@ -3351,6 +3479,7 @@
         {
             "version": "0.13.31",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.31",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.31",
@@ -3420,6 +3549,7 @@
         {
             "version": "0.13.32",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.31",
             "isBeta": true,
             "downloads": {
@@ -3430,6 +3560,7 @@
         {
             "version": "0.13.33",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.31",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.13.33",
@@ -3441,6 +3572,7 @@
         {
             "version": "0.14.0",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.31",
             "isBeta": true,
             "downloads": {
@@ -3451,6 +3583,7 @@
         {
             "version": "0.14.1",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.13.31",
             "isBeta": true,
             "downloads": {
@@ -3461,6 +3594,7 @@
         {
             "version": "0.14.2",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.2",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.14.2",
@@ -3512,6 +3646,7 @@
         {
             "version": "0.14.3",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.2",
             "isBeta": true,
             "downloads": {
@@ -3522,6 +3657,7 @@
         {
             "version": "0.14.4",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.2",
             "isBeta": true,
             "downloads": {
@@ -3532,6 +3668,7 @@
         {
             "version": "0.14.5",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.14.5",
@@ -3592,6 +3729,7 @@
         {
             "version": "0.14.6",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.14.6",
@@ -3652,6 +3790,7 @@
         {
             "version": "0.14.7",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3662,6 +3801,7 @@
         {
             "version": "0.14.8",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3672,6 +3812,7 @@
         {
             "version": "0.14.9",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3682,6 +3823,7 @@
         {
             "version": "0.14.10",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3692,6 +3834,7 @@
         {
             "version": "0.14.11",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3702,6 +3845,7 @@
         {
             "version": "0.14.12",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3712,6 +3856,7 @@
         {
             "version": "0.14.13",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3722,6 +3867,7 @@
         {
             "version": "0.14.14",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.6",
             "isBeta": true,
             "downloads": {
@@ -3732,6 +3878,7 @@
         {
             "version": "0.14.15",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.14.15",
@@ -3792,6 +3939,7 @@
         {
             "version": "0.15.0",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": true,
             "downloads": {
@@ -3802,6 +3950,7 @@
         {
             "version": "0.15.1",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": true,
             "downloads": {
@@ -3812,6 +3961,7 @@
         {
             "version": "0.15.2",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": true,
             "downloads": {
@@ -3822,6 +3972,7 @@
         {
             "version": "0.15.3",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": true,
             "downloads": {
@@ -3832,6 +3983,7 @@
         {
             "version": "0.15.4",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": true,
             "downloads": {
@@ -3842,6 +3994,7 @@
         {
             "version": "0.15.5",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.14.15",
             "isBeta": true,
             "downloads": {
@@ -3852,6 +4005,7 @@
         {
             "version": "0.15.6",
             "minInstallerVersion": "0.11.0",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.15.6",
@@ -3912,6 +4066,7 @@
         {
             "version": "0.15.7",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.6",
             "isBeta": true,
             "downloads": {
@@ -3922,6 +4077,7 @@
         {
             "version": "0.15.8",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.8",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.15.8",
@@ -3982,6 +4138,7 @@
         {
             "version": "0.15.9",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v0.15.9",
@@ -4051,6 +4208,7 @@
         {
             "version": "0.16.0",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": true,
             "downloads": {
@@ -4061,6 +4219,7 @@
         {
             "version": "0.16.1",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": true,
             "downloads": {
@@ -4071,6 +4230,7 @@
         {
             "version": "0.16.2",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": true,
             "downloads": {
@@ -4081,6 +4241,7 @@
         {
             "version": "0.16.3",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": true,
             "downloads": {
@@ -4091,6 +4252,7 @@
         {
             "version": "0.16.4",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": true,
             "downloads": {
@@ -4101,6 +4263,7 @@
         {
             "version": "0.16.5",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "0.15.9",
             "isBeta": true,
             "downloads": {
@@ -4111,6 +4274,7 @@
         {
             "version": "1.0.0",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.0",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.0.0",
@@ -4180,6 +4344,7 @@
         {
             "version": "1.0.2",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.0",
             "isBeta": true,
             "downloads": {
@@ -4190,6 +4355,7 @@
         {
             "version": "1.0.3",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.0.3",
@@ -4259,6 +4425,7 @@
         {
             "version": "1.1.0",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4269,6 +4436,7 @@
         {
             "version": "1.1.1",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4279,6 +4447,7 @@
         {
             "version": "1.1.2",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4289,6 +4458,7 @@
         {
             "version": "1.1.3",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4299,6 +4469,7 @@
         {
             "version": "1.1.4",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4309,6 +4480,7 @@
         {
             "version": "1.1.5",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4319,6 +4491,7 @@
         {
             "version": "1.1.6",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4329,6 +4502,7 @@
         {
             "version": "1.1.7",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.0.3",
             "isBeta": true,
             "downloads": {
@@ -4339,6 +4513,7 @@
         {
             "version": "1.1.8",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.8",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.1.8",
@@ -4408,6 +4583,7 @@
         {
             "version": "1.1.9",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.9",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.1.9",
@@ -4477,6 +4653,7 @@
         {
             "version": "1.1.10",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.9",
             "isBeta": true,
             "downloads": {
@@ -4487,6 +4664,7 @@
         {
             "version": "1.1.11",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.9",
             "isBeta": true,
             "downloads": {
@@ -4497,6 +4675,7 @@
         {
             "version": "1.1.12",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.9",
             "isBeta": true,
             "downloads": {
@@ -4507,6 +4686,7 @@
         {
             "version": "1.1.13",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.9",
             "isBeta": true,
             "downloads": {
@@ -4517,6 +4697,7 @@
         {
             "version": "1.1.14",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.9",
             "isBeta": true,
             "downloads": {
@@ -4527,6 +4708,7 @@
         {
             "version": "1.1.15",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.15",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.1.15",
@@ -4596,6 +4778,7 @@
         {
             "version": "1.1.16",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.1.16",
@@ -4665,6 +4848,7 @@
         {
             "version": "1.2.0",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4675,6 +4859,7 @@
         {
             "version": "1.2.1",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4685,6 +4870,7 @@
         {
             "version": "1.2.2",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4695,6 +4881,7 @@
         {
             "version": "1.2.3",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4705,6 +4892,7 @@
         {
             "version": "1.2.4",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4715,6 +4903,7 @@
         {
             "version": "1.2.5",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4725,6 +4914,7 @@
         {
             "version": "1.2.6",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.1.16",
             "isBeta": true,
             "downloads": {
@@ -4735,6 +4925,7 @@
         {
             "version": "1.2.7",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.2.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.2.7",
@@ -4804,6 +4995,7 @@
         {
             "version": "1.2.8",
             "minInstallerVersion": "0.14.5",
+            "minRunnableInstallerVersion": "0.6.4",
             "maxInstallerVersion": "1.2.8",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.2.8",
@@ -4873,6 +5065,7 @@
         {
             "version": "1.3.0",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.2.8",
             "isBeta": true,
             "downloads": {
@@ -4883,6 +5076,7 @@
         {
             "version": "1.3.1",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.2.8",
             "isBeta": true,
             "downloads": {
@@ -4893,6 +5087,7 @@
         {
             "version": "1.3.2",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.2.8",
             "isBeta": true,
             "downloads": {
@@ -4903,6 +5098,7 @@
         {
             "version": "1.3.3",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.3.3",
@@ -4972,6 +5168,7 @@
         {
             "version": "1.3.4",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.3.4",
@@ -5041,6 +5238,7 @@
         {
             "version": "1.3.5",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.3.5",
@@ -5110,6 +5308,7 @@
         {
             "version": "1.3.6",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.5",
             "isBeta": true,
             "downloads": {
@@ -5120,6 +5319,7 @@
         {
             "version": "1.3.7",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.3.7",
@@ -5189,6 +5389,7 @@
         {
             "version": "1.4.0",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.7",
             "isBeta": true,
             "downloads": {
@@ -5199,6 +5400,7 @@
         {
             "version": "1.4.1",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.7",
             "isBeta": true,
             "downloads": {
@@ -5209,6 +5411,7 @@
         {
             "version": "1.4.2",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.7",
             "isBeta": true,
             "downloads": {
@@ -5219,6 +5422,7 @@
         {
             "version": "1.4.3",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.7",
             "isBeta": true,
             "downloads": {
@@ -5229,6 +5433,7 @@
         {
             "version": "1.4.4",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.3.7",
             "isBeta": true,
             "downloads": {
@@ -5239,6 +5444,7 @@
         {
             "version": "1.4.5",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.5",
@@ -5308,6 +5514,7 @@
         {
             "version": "1.4.6",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.5",
             "isBeta": true,
             "downloads": {
@@ -5318,6 +5525,7 @@
         {
             "version": "1.4.9",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.5",
             "isBeta": true,
             "downloads": {
@@ -5328,6 +5536,7 @@
         {
             "version": "1.4.10",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.10",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.10",
@@ -5397,6 +5606,7 @@
         {
             "version": "1.4.11",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.11",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.11",
@@ -5466,6 +5676,7 @@
         {
             "version": "1.4.12",
             "minInstallerVersion": "1.1.9",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.12",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.12",
@@ -5535,6 +5746,7 @@
         {
             "version": "1.4.13",
             "minInstallerVersion": "1.4.5",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.13",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.13",
@@ -5604,6 +5816,7 @@
         {
             "version": "1.4.14",
             "minInstallerVersion": "1.4.5",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.14",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.14",
@@ -5673,6 +5886,7 @@
         {
             "version": "1.4.15",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.14",
             "isBeta": true,
             "downloads": {
@@ -5683,6 +5897,7 @@
         {
             "version": "1.4.16",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.16",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.4.16",
@@ -5752,6 +5967,7 @@
         {
             "version": "1.5.0",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.16",
             "isBeta": true,
             "downloads": {
@@ -5762,6 +5978,7 @@
         {
             "version": "1.5.1",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.16",
             "isBeta": true,
             "downloads": {
@@ -5772,6 +5989,7 @@
         {
             "version": "1.5.2",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "0.14.5",
             "maxInstallerVersion": "1.4.16",
             "isBeta": true,
             "downloads": {
@@ -5782,6 +6000,7 @@
         {
             "version": "1.5.3",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.5.3",
@@ -5851,6 +6070,7 @@
         {
             "version": "1.5.4",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.3",
             "isBeta": true,
             "downloads": {
@@ -5861,6 +6081,7 @@
         {
             "version": "1.5.5",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.3",
             "isBeta": true,
             "downloads": {
@@ -5871,6 +6092,7 @@
         {
             "version": "1.5.6",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.3",
             "isBeta": true,
             "downloads": {
@@ -5881,6 +6103,7 @@
         {
             "version": "1.5.7",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.3",
             "isBeta": true,
             "downloads": {
@@ -5891,6 +6114,7 @@
         {
             "version": "1.5.8",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.8",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.5.8",
@@ -5961,6 +6185,7 @@
         {
             "version": "1.5.9",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.8",
             "isBeta": true,
             "downloads": {
@@ -5971,6 +6196,7 @@
         {
             "version": "1.5.10",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.8",
             "isBeta": true,
             "downloads": {
@@ -5981,6 +6207,7 @@
         {
             "version": "1.5.11",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.11",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.5.11",
@@ -6051,6 +6278,7 @@
         {
             "version": "1.5.12",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.12",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.5.12",
@@ -6121,6 +6349,7 @@
         {
             "version": "1.6.0",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.12",
             "isBeta": true,
             "downloads": {
@@ -6131,6 +6360,7 @@
         {
             "version": "1.6.1",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.5.12",
             "isBeta": true,
             "downloads": {
@@ -6141,6 +6371,7 @@
         {
             "version": "1.6.2",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.2",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.6.2",
@@ -6211,6 +6442,7 @@
         {
             "version": "1.6.3",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.6.3",
@@ -6281,6 +6513,7 @@
         {
             "version": "1.6.4",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.3",
             "isBeta": true,
             "downloads": {
@@ -6291,6 +6524,7 @@
         {
             "version": "1.6.5",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.6.5",
@@ -6363,6 +6597,7 @@
         {
             "version": "1.6.6",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.5",
             "isBeta": true,
             "downloads": {
@@ -6373,6 +6608,7 @@
         {
             "version": "1.6.7",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.6.7",
@@ -6445,6 +6681,7 @@
         {
             "version": "1.7.0",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.7",
             "isBeta": true,
             "downloads": {
@@ -6455,6 +6692,7 @@
         {
             "version": "1.7.1",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.7",
             "isBeta": true,
             "downloads": {
@@ -6465,6 +6703,7 @@
         {
             "version": "1.7.2",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.7",
             "isBeta": true,
             "downloads": {
@@ -6475,6 +6714,7 @@
         {
             "version": "1.7.3",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.6.7",
             "isBeta": true,
             "downloads": {
@@ -6485,6 +6725,7 @@
         {
             "version": "1.7.4",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.7.4",
@@ -6557,6 +6798,7 @@
         {
             "version": "1.7.5",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.7.5",
@@ -6629,6 +6871,7 @@
         {
             "version": "1.7.6",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.7.6",
@@ -6701,6 +6944,7 @@
         {
             "version": "1.7.7",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.7.7",
@@ -6773,6 +7017,7 @@
         {
             "version": "1.8.0",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.7",
             "isBeta": true,
             "downloads": {
@@ -6783,6 +7028,7 @@
         {
             "version": "1.8.1",
             "minInstallerVersion": "1.4.13",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.7",
             "isBeta": true,
             "downloads": {
@@ -6793,6 +7039,7 @@
         {
             "version": "1.8.2",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.7.7",
             "isBeta": true,
             "downloads": {
@@ -6803,6 +7050,7 @@
         {
             "version": "1.8.3",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.8.3",
@@ -6875,6 +7123,7 @@
         {
             "version": "1.8.4",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.8.4",
@@ -6947,6 +7196,7 @@
         {
             "version": "1.8.5",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.4",
             "isBeta": true,
             "downloads": {
@@ -6957,6 +7207,7 @@
         {
             "version": "1.8.6",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.4",
             "isBeta": true,
             "downloads": {
@@ -6967,6 +7218,7 @@
         {
             "version": "1.8.7",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.8.7",
@@ -7039,6 +7291,7 @@
         {
             "version": "1.8.8",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.7",
             "isBeta": true,
             "downloads": {
@@ -7049,6 +7302,7 @@
         {
             "version": "1.8.9",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.9",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.8.9",
@@ -7121,6 +7375,7 @@
         {
             "version": "1.8.10",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.8.10",
@@ -7193,6 +7448,7 @@
         {
             "version": "1.9.0",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7203,6 +7459,7 @@
         {
             "version": "1.9.1",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7213,6 +7470,7 @@
         {
             "version": "1.9.2",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7223,6 +7481,7 @@
         {
             "version": "1.9.3",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7233,6 +7492,7 @@
         {
             "version": "1.9.4",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7243,6 +7503,7 @@
         {
             "version": "1.9.5",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7253,6 +7514,7 @@
         {
             "version": "1.9.6",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7263,6 +7525,7 @@
         {
             "version": "1.9.7",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7273,6 +7536,7 @@
         {
             "version": "1.9.8",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7283,6 +7547,7 @@
         {
             "version": "1.9.9",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.8.10",
             "isBeta": true,
             "downloads": {
@@ -7293,6 +7558,7 @@
         {
             "version": "1.9.10",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.10",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.9.10",
@@ -7365,6 +7631,7 @@
         {
             "version": "1.9.11",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.10",
             "isBeta": true,
             "downloads": {
@@ -7375,6 +7642,7 @@
         {
             "version": "1.9.12",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.12",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.9.12",
@@ -7447,6 +7715,7 @@
         {
             "version": "1.9.13",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.12",
             "isBeta": true,
             "downloads": {
@@ -7457,6 +7726,7 @@
         {
             "version": "1.9.14",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.14",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.9.14",
@@ -7529,6 +7799,7 @@
         {
             "version": "1.10.0",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.14",
             "isBeta": true,
             "downloads": {
@@ -7539,6 +7810,7 @@
         {
             "version": "1.10.1",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.14",
             "isBeta": true,
             "downloads": {
@@ -7549,6 +7821,7 @@
         {
             "version": "1.10.2",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.9.14",
             "isBeta": true,
             "downloads": {
@@ -7559,6 +7832,7 @@
         {
             "version": "1.10.3",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.3",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.10.3",
@@ -7631,6 +7905,7 @@
         {
             "version": "1.10.4",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.3",
             "isBeta": true,
             "downloads": {
@@ -7641,6 +7916,7 @@
         {
             "version": "1.10.5",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.3",
             "isBeta": true,
             "downloads": {
@@ -7651,6 +7927,7 @@
         {
             "version": "1.10.6",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.6",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.10.6",
@@ -7723,6 +8000,7 @@
         {
             "version": "1.11.0",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.6",
             "isBeta": true,
             "downloads": {
@@ -7733,6 +8011,7 @@
         {
             "version": "1.11.1",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.6",
             "isBeta": true,
             "downloads": {
@@ -7743,6 +8022,7 @@
         {
             "version": "1.11.2",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.6",
             "isBeta": true,
             "downloads": {
@@ -7753,6 +8033,7 @@
         {
             "version": "1.11.3",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.10.6",
             "isBeta": true,
             "downloads": {
@@ -7763,6 +8044,7 @@
         {
             "version": "1.11.4",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.11.4",
@@ -7835,6 +8117,7 @@
         {
             "version": "1.11.5",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.5",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.11.5",
@@ -7907,6 +8190,7 @@
         {
             "version": "1.11.6",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.5",
             "isBeta": true,
             "downloads": {
@@ -7917,6 +8201,7 @@
         {
             "version": "1.11.7",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.11.7",
@@ -7989,6 +8274,7 @@
         {
             "version": "1.12.0",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.7",
             "isBeta": true,
             "downloads": {
@@ -7999,6 +8285,7 @@
         {
             "version": "1.12.1",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.7",
             "isBeta": true,
             "downloads": {
@@ -8009,6 +8296,7 @@
         {
             "version": "1.12.2",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.7",
             "isBeta": true,
             "downloads": {
@@ -8019,6 +8307,7 @@
         {
             "version": "1.12.3",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.11.7",
             "isBeta": true,
             "downloads": {
@@ -8029,6 +8318,7 @@
         {
             "version": "1.12.4",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.12.4",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.12.4",
@@ -8101,6 +8391,7 @@
         {
             "version": "1.12.5",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.12.4",
             "isBeta": true,
             "downloads": {
@@ -8111,6 +8402,7 @@
         {
             "version": "1.12.6",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.12.4",
             "isBeta": true,
             "downloads": {
@@ -8121,6 +8413,7 @@
         {
             "version": "1.12.7",
             "minInstallerVersion": "1.5.8",
+            "minRunnableInstallerVersion": "1.1.9",
             "maxInstallerVersion": "1.12.7",
             "isBeta": false,
             "gitHubRelease": "https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.12.7",
@@ -8193,6 +8486,7 @@
         {
             "version": "1.13.0",
             "minInstallerVersion": "1.6.5",
+            "minRunnableInstallerVersion": "1.6.5",
             "maxInstallerVersion": "1.12.7",
             "isBeta": true,
             "downloads": {
@@ -8203,6 +8497,7 @@
         {
             "version": "1.13.1",
             "minInstallerVersion": "1.6.5",
+            "minRunnableInstallerVersion": "1.6.5",
             "maxInstallerVersion": "1.12.7",
             "isBeta": true,
             "downloads": {

--- a/packages/obsidian-launcher/src/launcherUtils.ts
+++ b/packages/obsidian-launcher/src/launcherUtils.ts
@@ -14,7 +14,7 @@ import CDP from "chrome-remote-interface";
 import { ObsidianLauncher } from "./launcher.js";
 import {
     consola, atomicCreate, makeTmpDir, normalizeObject, pool, maybe, withTimeout, until, retry, UntilOpts,
-    tryParseJson,
+    tryParseJson, findFirstPassing,
 } from "./utils.js";
 import { downloadResponse, fetchGitHubAPIPaginated } from "./apis.js"
 import {
@@ -467,11 +467,19 @@ export async function extractInstallerInfo(
 }
 
 /**
+ * The result of checking an Obsidian app version against an installer version:
+ * - `"compatible"`: the app launches without warnings
+ * - `"warning"`: the app launches but Obsidian shows an "installer version too low" warning
+ * - `"error"`: the installer is too old to launch the app at all
+ */
+export type CompatibilityResult = "error" | "warning" | "compatible";
+
+/**
  * Checks if an Obsidian app and installer version are compatible.
  */
 export async function checkCompatibility(
     launcher: ObsidianLauncher, appVersion: string, installerVersion: string,
-) {
+): Promise<CompatibilityResult> {
     [appVersion, installerVersion] = await launcher.resolveVersion(appVersion, installerVersion);
     consola.log(`Checking if app ${appVersion} and installer ${installerVersion} are compatible...`)
     // getCdpSession will download, but do it here first so we don't interpret network errors as launch failure
@@ -485,20 +493,22 @@ export async function checkCompatibility(
         {retries: 3, backoff: 4000},
     ));
     if (!cdpResult.success) {
+        // note getCdpSession will also fail if electron fails but the Obsidian app doesn't load
         consola.log(`app ${appVersion} with installer ${installerVersion} failed to launch: ${cdpResult.error}`);
-        return false;
+        return "error";
     }
 
     const { client, cleanup } = cdpResult.result;
-    let result = true;
+    let result: CompatibilityResult = "compatible";
     try {
-        const loadedAppVersion = await cdpEvaluate(client, `window.obsidianLauncher.obsidian.apiVersion`)
+        let loadedAppVersion = await cdpEvaluate(client, `window.obsidianLauncher?.obsidian?.apiVersion`);
         if (loadedAppVersion && loadedAppVersion != appVersion) {
-            result = false;
+            // on some old installers, it will fall back to running the bundled asar instead of the incompatible app
+            result = "error";
         } else if (semver.lt(appVersion, "0.7.4")) {
             // versions <0.7.4 show incompatibility warnings even for the installer of the same version. Something
             // must be broken with the installers listed in the release? Just setting these manually.
-            result = semver.gte(installerVersion, '0.6.4');
+            result = semver.gte(installerVersion, '0.6.4') ? "compatible" : "warning";
         } else if (semver.lt(appVersion, "0.13.4")) {
             // the debug command was added in 0.13.4, so check the about page before then
             await cdpEvaluate(client, `window.app.commands.executeCommandById('app:open-settings')`);
@@ -508,24 +518,29 @@ export async function checkCompatibility(
                     document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
                 ).singleNodeValue.click() ?? true;
             `), {timeout: 5000});
-            const aboutText = await until(() => cdpEvaluate(client, `
+            const aboutText: string = await until(() => cdpEvaluate(client, `
                 document.evaluate(
                     "//*[contains(@class, 'setting-item-name') and contains(text(),'Current version:')]",
                     document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
                 ).singleNodeValue.parentNode.innerText;
             `), {timeout: 5000});
-            if (['manual installation', "manually install"].some(t => aboutText.includes(t))) {
-                result = false;
+            // plugins don't work below 0.12.8, so window.obsidianLauncher isn't set. So check the app version matches here
+            loadedAppVersion = aboutText.match(/Current version:\s*v?(\d+\.\d+\.\d+)/)?.[1];
+            if (loadedAppVersion != appVersion) {
+                result = "error";
+            } else if (['manual installation', "manually install"].some(t => aboutText.includes(t))) {
+                result = "warning";
             }
         } else {
             // check the debug info for installer incompatibility warning
+            // note, old installers don't support the debug command (less than 0.9.17) so treat failure as incompatible
             await cdpEvaluate(client, `window.obsidianLauncher.app.commands.executeCommandById('app:show-debug-info')`);
             const debugInfo: string = await cdpEvaluateUntil(client,
                 `document.querySelector(".debug-textarea").value.trim()`,
                 {timeout: 5000},
-            );
-            if (debugInfo.toLowerCase().match(/installer version too low/)) {
-                result = false;
+            ).catch(() => "");
+            if (debugInfo == "" || debugInfo.toLowerCase().match(/installer version too low/)) {
+                result = "warning";
             }
         }
     } finally {
@@ -533,7 +548,7 @@ export async function checkCompatibility(
         await fsAsync.rm(vault, {recursive: true, force: true});
     }
 
-    consola.log(`app ${appVersion} and installer ${installerVersion} are ${!result ? 'in' : ''}compatible`);
+    consola.log(`app ${appVersion} and installer ${installerVersion} compatibility: ${result}`);
     return result;
 }
 
@@ -581,45 +596,50 @@ export async function getCompatibilityInfos(
 
         // create array of only installer versions
         const installerArr = versionArr.filter(v => !!v.downloads.appImage);
-        // map installer versions to their index
-        const installerIndexMap = _.fromPairs(installerArr.map((v, i) => [v.version, i]));
+        const checkCompatibilityCached = _.memoize(
+            (app: string, installer: string) => _checkCompatibility(launcher, app, installer),
+            (app: string, installer: string) => `${app}/${installer}`,
+        )
 
-        // populate minInstallerVersion
+        // populate minInstallerVersion and minRunnableInstallerVersion
         for (const [i, version] of versionArr.entries()) {
-            if (version.minInstallerVersion) {
+            if (version.minInstallerVersion && version.minRunnableInstallerVersion) {
                 continue;
             }
-            // do a binary search of sorts to find the first "compatible" installer
             const prev = i > 0 ? versionArr[i - 1] : undefined;
-            let start = prev ? installerIndexMap[prev.minInstallerVersion!] : 0;
-            let end = installerIndexMap[version.maxInstallerVersion!];
+   
+            const minInstallerVersion = await findFirstPassing(installerArr,
+                async (v) => (await checkCompatibilityCached(version.version, v.version)) == "compatible",
+                prev ? installerArr.findIndex(v => v.version == prev.minInstallerVersion) : 0,
+                installerArr.findIndex(v => v.version == version.maxInstallerVersion) + 1,
+            );
+            const minRunnableInstallerVersion = await findFirstPassing(installerArr,
+                async (v) => ['warning', 'compatible'].includes(await checkCompatibilityCached(version.version, v.version)),
+                prev ? installerArr.findIndex(v => v.version == prev.minRunnableInstallerVersion) : 0,
+                installerArr.findIndex(v => v.version == version.maxInstallerVersion) + 1,
+            );
 
-            while (start <= end) {
-                const mid = Math.floor((start + end) / 2);
-                const compatible = await _checkCompatibility(launcher,
-                    version.version, installerArr[mid].version,
-                );
-                if (!compatible) {
-                    start = mid + 1;
-                } else {
-                    end = mid - 1;
-                }
+            if (!minInstallerVersion || !minRunnableInstallerVersion) {
+                throw Error(`${version.version} incompatible with all installers`)
             }
-            if (start > installerIndexMap[version.maxInstallerVersion!]) {
-                throw Error(`${version.version} failed to launch for all installers`)
-            }
-            version.minInstallerVersion = installerArr[start].version;
+
+            version.minInstallerVersion = minInstallerVersion.version;
+            version.minRunnableInstallerVersion = minRunnableInstallerVersion.version;
         }
 
         // Return only new information
         const origVersions = _(versions)
-            .map(v => _.pick(v, ["version", "minInstallerVersion", "maxInstallerVersion"]))
+            .map(v => _.pick(v, [
+                "version", "minInstallerVersion", "minRunnableInstallerVersion", "maxInstallerVersion",
+            ]))
             .keyBy(v => v.version)
             .value();
         return versionArr
             .map(v => ({
                 version: v.version,
-                minInstallerVersion: v.minInstallerVersion!, maxInstallerVersion: v.maxInstallerVersion!,
+                minInstallerVersion: v.minInstallerVersion!,
+                minRunnableInstallerVersion: v.minRunnableInstallerVersion!,
+                maxInstallerVersion: v.maxInstallerVersion!,
             }))
             .filter(v => !_.isEqual(v, origVersions[v.version]));
     } finally {
@@ -643,6 +663,7 @@ export function normalizeObsidianVersionInfo(versionInfo: DeepPartial<ObsidianVe
     const canonicalForm = {
         version: null,
         minInstallerVersion: null,
+        minRunnableInstallerVersion: null,
         maxInstallerVersion: null,
         isBeta: null,
         gitHubRelease: null,

--- a/packages/obsidian-launcher/src/types.ts
+++ b/packages/obsidian-launcher/src/types.ts
@@ -1,4 +1,4 @@
-export const obsidianVersionsSchemaVersion = '2.0.0';
+export const obsidianVersionsSchemaVersion = '2.1.0';
 
 /**
  * Type of the obsidian-versions.json file.
@@ -40,7 +40,13 @@ export type ObsidianInstallerInfo = {
  */
 export type ObsidianVersionInfo = {
     version: string,
+    /** Minimum installer version that is fully compatible with this app version */
     minInstallerVersion?: string,
+    /**
+     * Minimum installer version that will run at all. An installer version between minRunnableInstallerVersion and minInstallerVersion
+     * will launch, but Obsidian will show warnings about installer compatibility and some features may not work.
+     */
+    minRunnableInstallerVersion?: string,
     maxInstallerVersion?: string,
     isBeta: boolean,
     gitHubRelease?: string,

--- a/packages/obsidian-launcher/src/utils.ts
+++ b/packages/obsidian-launcher/src/utils.ts
@@ -297,3 +297,31 @@ export function normalizeObject<T>(canonical: CanonicalForm, obj: T): T {
     }
     return helper(rootCanonical, rootObj);
 }
+
+
+/**
+ * Use a binary search to find the first entry that passes check. Assumes the list is in order such that all that fail
+ * the check are before all that pass the check.
+ * start and end range is [start, end)
+ */
+export async function findFirstPassing<T>(
+    arr: T[], check: (x: T) => Promise<boolean>|boolean, start = 0, end = arr.length,
+): Promise<T | undefined> {
+    if (start < 0 || end > arr.length || end < start) throw new Error(`Invalid start/end: ${start} -> ${end}`);
+    const origEnd = end;
+
+    if (start < end && await check(arr[start])) { // optimization for the common case where all in range are passing
+        return arr[start];
+    }
+    start += 1;
+
+    while (start < end) {
+        const mid = Math.floor((start + end) / 2);
+        if (await check(arr[mid])) {
+            end = mid;
+        } else {
+            start = mid + 1;
+        }
+    }
+    return start < origEnd ? arr[start] : undefined;
+}

--- a/packages/obsidian-launcher/test/e2e/launcher.spec.ts
+++ b/packages/obsidian-launcher/test/e2e/launcher.spec.ts
@@ -123,15 +123,15 @@ describe("ObsidianLauncher", function() {
 
     it("test checkCompatibility compatible", async function() {
         if (process.env.TEST_LEVEL != "all") this.skip();
-        expect(await checkCompatibility(launcher, latest, latestMinInstaller)).to.equal(true);
-        expect(await checkCompatibility(launcher, ...versions[0])).to.equal(true);
+        expect(await checkCompatibility(launcher, latest, latestMinInstaller)).to.equal("compatible");
+        expect(await checkCompatibility(launcher, ...versions[0])).to.equal("compatible");
     })
 
     it("test checkCompatibility incompatible", async function() {
         if (process.env.TEST_LEVEL != "all") this.skip();
         const installers = versions.map(v => v[1]).sort(semver.compare);
         const incompatibleInstaller = _.findLast(installers, v => semver.lt(v, latestMinInstaller))!;
-        expect(await checkCompatibility(launcher, latest, incompatibleInstaller)).to.equal(false);
+        expect(await checkCompatibility(launcher, latest, incompatibleInstaller)).to.not.equal("compatible");
     })
 
     for (const [appVersion, installerVersion] of versions) {

--- a/packages/obsidian-launcher/test/unit/launcherUtils.spec.ts
+++ b/packages/obsidian-launcher/test/unit/launcherUtils.spec.ts
@@ -9,7 +9,7 @@ import fs from "fs";
 import fsAsync from "fs/promises";
 import semver from "semver"
 import _ from "lodash";
-import { ObsidianVersionInfo, ObsidianVersionList } from "../../src/types.js";
+import { ObsidianVersionInfo, ObsidianVersionList, obsidianVersionsSchemaVersion } from "../../src/types.js";
 import { ObsidianDesktopRelease } from "../../src/obsidianTypes.js";
 
 
@@ -128,7 +128,7 @@ describe("updateObsidianVersionList", function() {
     ) {
         const { destkopReleases, githubReleases, _extractInstallerInfo, _checkCompatibility } = opts;
         const metadata = { // dummy metadata
-            schemaVersion: "2.0.0",
+            schemaVersion: obsidianVersionsSchemaVersion,
             commitDate: "1970-01-01T00:00:00Z",
             commitSha: "0000000000000000000000000000000000000000",
             timestamp: timestamp,
@@ -152,10 +152,19 @@ describe("updateObsidianVersionList", function() {
                     return installerInfo;
                 }),
                 _checkCompatibility: _checkCompatibility ?? (async (_, appVersion, installerVersion) => {
-                    if (!fullVersionsMap[appVersion].minInstallerVersion) {
+                    const info = fullVersionsMap[appVersion];
+                    if (!info.minInstallerVersion) {
                         throw Error(`No minInstallerVersion for ${appVersion}`);
                     }
-                    return semver.gte(installerVersion, fullVersionsMap[appVersion].minInstallerVersion);
+                    if (semver.gte(installerVersion, info.minInstallerVersion)) {
+                        return "compatible";
+                    } else if (info.minRunnableInstallerVersion &&
+                        semver.gte(installerVersion, info.minRunnableInstallerVersion)
+                    ) {
+                        return "warning";
+                    } else {
+                        return "error";
+                    }
                 }),
             },
         );

--- a/packages/obsidian-launcher/test/unit/utils.spec.ts
+++ b/packages/obsidian-launcher/test/unit/utils.spec.ts
@@ -5,7 +5,7 @@ import path from "path"
 import { createDirectory } from "../helpers.js";
 import {
     fileExists, atomicCreate, linkOrCp, pathIsUnder, sleep, withTimeout, pool, maybe, normalizeObject,
-    CanonicalForm, until, retry,
+    CanonicalForm, until, retry, findFirstPassing,
 } from "../../src/utils.js";
 
 
@@ -362,5 +362,48 @@ describe("retry", () => {
         }).catch(r => r);
         expect(result).to.be.instanceOf(Error);
         expect(result.toString()).to.match(/unrecoverable/);
+    });
+})
+
+describe("findFirstPassing", () => {
+    const tests: {
+        name: string,
+        arr: any[], cond: (x: any) => boolean,
+        start?: any, end?: any,
+        expected: any,
+    }[] = [
+        {name: "middle", arr: [1, 2, 3, 4, 5], cond: x => x >= 3, expected: 3},
+        {name: "strings", arr: ['a', 'b', 'c', 'd', 'e'], cond: x => x >= "c", expected: "c"},
+        {name: "first element", arr: [1, 2, 3, 4, 5], cond: x => x >= 0, expected: 1},
+        {name: "last element", arr: [1, 2, 3, 4, 5], cond: x => x >= 5, expected: 5},
+        {name: "none pass", arr: [1, 2, 3, 4, 5], cond: x => x >= 6, expected: undefined},
+        {name: "all pass", arr: [1, 2, 3, 4, 5], cond: x => x >= -1, expected: 1},
+        {name: "single passing", arr: [5], cond: x => x >= 3, expected: 5},
+        {name: "single failing", arr: [1], cond: x => x >= 3, expected: undefined},
+        {name: "even length", arr: [1, 2, 3, 4, 5, 6], cond: x => x >= 4, expected: 4},
+        {name: "duplicates", arr: [1, 2, 2, 2, 3], cond: x => x >= 2, expected: 2},
+        {name: "bounds", arr: [1, 2, 3, 4, 5], start: 1, end: 4, cond: x => x >= 0, expected: 2},
+        {name: "end is exclusive", arr: [1, 2, 3, 4, 5], start: 0, end: 2, cond: x => x >= 3, expected: undefined},
+        {name: "no match", arr: [1, 2, 3, 4, 5], start: 0, end: 3, cond: x => x >= 10, expected: undefined},
+        {name: "empty range", arr: [1, 2, 3, 4, 5], start: 2, end: 2, cond: x => x >= 0, expected: undefined},
+        {name: "empty", arr: [], cond: () => true, expected: undefined},
+        {name: "single element passing", arr: [1, 2, 3, 4, 5], start: 2, end: 3, cond: x => x >= 3, expected: 3},
+        {name: "single element failing", arr: [1, 2, 3, 4, 5], start: 2, end: 3, cond: x => x >= 4, expected: undefined},
+    ];
+
+    tests.forEach(({name, arr, start, end, cond, expected}) => {
+        it(name, async () => {
+            const result = await findFirstPassing(arr, cond, start, end);
+            expect(result).to.equal(expected);
+        });
+    });
+
+    it("async", async () => {
+        const arr = [1, 2, 3, 4, 5];
+        const result = await findFirstPassing(arr, async (x) => {
+            await sleep(1);
+            return x >= 3;
+        });
+        expect(result).to.equal(3);
     });
 })


### PR DESCRIPTION
minInstallerVersion checks for the installer version that is fully compatible with the app (i.e. Obsidian won't show any "installer version to low" warnings).

Add `minRunnableInstallerVersion` which is the minimum installer version necessary to launch the app. Some users can theoretically still be using this version, but Obsidian will warn them about installer compatibility, and some features may be broken.